### PR TITLE
APX-7103 force broadcaster to use redis, to prevent conflicts with so…

### DIFF
--- a/app/Broadcasts/AbstractBroadcast.php
+++ b/app/Broadcasts/AbstractBroadcast.php
@@ -3,11 +3,23 @@
 namespace Nexus\ApexEvents\Broadcasts;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\InteractsWithBroadcasting;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 abstract class AbstractBroadcast implements ShouldBroadcast
 {
     use InteractsWithSockets;
+    use InteractsWithBroadcasting;
     use SerializesModels;
+
+    /**
+     * Override the broadcaster driver to use redis, as the trait's property cannot be overriden by the
+     * implementing class.
+     * @return string[]
+     */
+    public function broadcastConnections()
+    {
+        return ['redis'];
+    }
 }


### PR DESCRIPTION
Set the extended class to use the redis driver, to avoid inheriting the global driver. 